### PR TITLE
Correção de seleção de nó

### DIFF
--- a/Webscaping/Program.cs
+++ b/Webscaping/Program.cs
@@ -9,7 +9,7 @@ htmlDoc.LoadHtml(response);
 string news = string.Empty;
 string link = string.Empty;
 
-foreach (HtmlNode node in htmlDoc.DocumentNode.SelectNodes("//div[@class='_evt']/a"))
+foreach (HtmlNode node in htmlDoc.DocumentNode.SelectNodes("//div[@class='_evt']/h2/a"))
 {
     if (node.Attributes.Count > 0)
     {


### PR DESCRIPTION
Alteração na seleção do nó na página do link para exibição correta do texto raspado.